### PR TITLE
Increase Mac timeout to 8 hours

### DIFF
--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -77,7 +77,7 @@ stages:
       ############ MACOS BUILD ############
       - job: Build_macOS
         displayName: macOS
-        timeoutInMinutes: 360
+        timeoutInMinutes: 480
         variables:
         - _BuildConfig: Release
         strategy:


### PR DESCRIPTION
Mac build is massively slow, increase timeout further so we don't hit the timeout on slow running builds