### PR TITLE
Add .cargo/config.toml for ittapi-rs

### DIFF
--- a/deps/v8/third_party/ittapi/ittapi-rs/.cargo/config.toml
+++ b/deps/v8/third_party/ittapi/ittapi-rs/.cargo/config.toml
@@ -1,5 +1,5 @@
 [registries]
-dotnet-public = { index = "sparse+https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/Cargo/index/" }
+"dotnet-public" = { index = "sparse+https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/Cargo/index/" }
 
 [source.crates-io]
-replace-with = dotnet-public
+replace-with = "dotnet-public"

--- a/deps/v8/third_party/ittapi/ittapi-rs/.cargo/config.toml
+++ b/deps/v8/third_party/ittapi/ittapi-rs/.cargo/config.toml
@@ -1,0 +1,5 @@
+[registries]
+dotnet-public = { index = "sparse+https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/Cargo/index/" }
+
+[source.crates-io]
+replace-with = dotnet-public


### PR DESCRIPTION
We don't use this dependency so the feed URL in config.toml doesn't matter.