### PR TITLE
Fix enum-constexpr-conversion warnings

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -400,7 +400,7 @@
       }],
       [ 'OS in "linux freebsd openbsd solaris android aix os400 cloudabi"', {
         'cflags': [ '-Wall', '-Wextra', '-Wno-unused-parameter', ],
-        'cflags_cc': [ '-fno-rtti', '-fno-exceptions', '-std=gnu++17', '-stdlib=libc++', '-Wno-error=enum-constexpr-conversion' ],
+        'cflags_cc': [ '-fno-rtti', '-fno-exceptions', '-std=gnu++17', '-stdlib=libc++' ],
         'defines': [ '__STDC_FORMAT_MACROS' ],
         'ldflags': [ '-rdynamic', '-fuse-ld=lld', '-Wl,--build-id' ],
         'target_conditions': [

--- a/deps/v8/src/base/bit-field.h
+++ b/deps/v8/src/base/bit-field.h
@@ -38,16 +38,14 @@ class BitField final {
   static constexpr U kMask = ((U{1} << kShift) << kSize) - (U{1} << kShift);
   static constexpr int kLastUsedBit = kShift + kSize - 1;
   static constexpr U kNumValues = U{1} << kSize;
-
-  // Value for the field with all bits set.
-  static constexpr T kMax = static_cast<T>(kNumValues - 1);
+  static constexpr U kMax = kNumValues - 1;
 
   template <class T2, int size2>
   using Next = BitField<T2, kShift + kSize, size2, U>;
 
   // Tells whether the provided value fits into the bit field.
   static constexpr bool is_valid(T value) {
-    return (static_cast<U>(value) & ~static_cast<U>(kMax)) == 0;
+    return (static_cast<U>(value) & ~kMax) == 0;
   }
 
   // Returns a type U with the bit field value encoded.

--- a/deps/v8/src/codegen/source-position.h
+++ b/deps/v8/src/codegen/source-position.h
@@ -100,23 +100,19 @@ class SourcePosition final {
   }
   void SetExternalLine(int line) {
     DCHECK(IsExternal());
-    DCHECK(line <= ExternalLineField::kMax - 1);
     value_ = ExternalLineField::update(value_, line);
   }
   void SetExternalFileId(int file_id) {
     DCHECK(IsExternal());
-    DCHECK(file_id <= ExternalFileIdField::kMax - 1);
     value_ = ExternalFileIdField::update(value_, file_id);
   }
 
   void SetScriptOffset(int script_offset) {
     DCHECK(IsJavaScript());
-    DCHECK(script_offset <= ScriptOffsetField::kMax - 2);
     DCHECK_GE(script_offset, kNoSourcePosition);
     value_ = ScriptOffsetField::update(value_, script_offset + 1);
   }
   void SetInliningId(int inlining_id) {
-    DCHECK(inlining_id <= InliningIdField::kMax - 2);
     DCHECK_GE(inlining_id, kNotInlined);
     value_ = InliningIdField::update(value_, inlining_id + 1);
   }

--- a/deps/v8/src/objects/allocation-site.h
+++ b/deps/v8/src/objects/allocation-site.h
@@ -78,7 +78,7 @@ class AllocationSite : public Struct {
   using MementoFoundCountBits = base::BitField<int, 0, 26>;
   using PretenureDecisionBits = base::BitField<PretenureDecision, 26, 3>;
   using DeoptDependentCodeBit = base::BitField<bool, 29, 1>;
-  STATIC_ASSERT(PretenureDecisionBits::kMax >= kLastPretenureDecisionValue);
+  STATIC_ASSERT(PretenureDecisionBits::is_valid(kLastPretenureDecisionValue));
 
   // Increments the mementos found counter and returns true when the first
   // memento was found for a given allocation site.

--- a/deps/v8/src/objects/bigint.cc
+++ b/deps/v8/src/objects/bigint.cc
@@ -1336,7 +1336,7 @@ uint32_t BigInt::GetBitfieldForSerialization() const {
   // In order to make the serialization format the same on 32/64 bit builds,
   // we convert the length-in-digits to length-in-bytes for serialization.
   // Being able to do this depends on having enough LengthBits:
-  STATIC_ASSERT(kMaxLength * kDigitSize <= LengthBits::kMax);
+  STATIC_ASSERT(LengthBits::is_valid(kMaxLength * kDigitSize));
   int bytelength = length() * kDigitSize;
   return SignBits::encode(sign()) | LengthBits::encode(bytelength);
 }

--- a/deps/v8/src/objects/code-inl.h
+++ b/deps/v8/src/objects/code-inl.h
@@ -606,7 +606,7 @@ uintptr_t Code::GetBaselinePCForNextExecutedBytecode(int bytecode_offset,
 
 void Code::initialize_flags(CodeKind kind, bool is_turbofanned, int stack_slots,
                             bool is_off_heap_trampoline) {
-  CHECK(0 <= stack_slots && stack_slots < StackSlotsField::kMax);
+  CHECK(StackSlotsField::is_valid(stack_slots));
   DCHECK(!CodeKindIsInterpretedJSFunction(kind));
   uint32_t flags = KindField::encode(kind) |
                    IsTurbofannedField::encode(is_turbofanned) |
@@ -1193,7 +1193,7 @@ int BytecodeArray::osr_urgency() const {
 
 void BytecodeArray::set_osr_urgency(int urgency) {
   DCHECK(0 <= urgency && urgency <= BytecodeArray::kMaxOsrUrgency);
-  STATIC_ASSERT(BytecodeArray::kMaxOsrUrgency <= OsrUrgencyBits::kMax);
+  STATIC_ASSERT(OsrUrgencyBits::is_valid(BytecodeArray::kMaxOsrUrgency));
   uint32_t value = osr_urgency_and_install_target();
   set_osr_urgency_and_install_target(OsrUrgencyBits::update(value, urgency));
 }

--- a/deps/v8/src/objects/code.h
+++ b/deps/v8/src/objects/code.h
@@ -996,7 +996,7 @@ class BytecodeArray
   // the function becomes hotter. When the current loop depth is less than the
   // osr_urgency, JumpLoop calls into runtime to attempt OSR optimization.
   static constexpr int kMaxOsrUrgency = 6;
-  STATIC_ASSERT(kMaxOsrUrgency <= OsrUrgencyBits::kMax);
+  STATIC_ASSERT(OsrUrgencyBits::is_valid(kMaxOsrUrgency));
   inline int osr_urgency() const;
   inline void set_osr_urgency(int urgency);
   inline void reset_osr_urgency();

--- a/deps/v8/src/objects/feedback-vector.cc
+++ b/deps/v8/src/objects/feedback-vector.cc
@@ -434,8 +434,8 @@ TieringState FeedbackVector::osr_tiering_state() {
 
 void FeedbackVector::set_osr_tiering_state(TieringState marker) {
   DCHECK(marker == TieringState::kNone || marker == TieringState::kInProgress);
-  STATIC_ASSERT(TieringState::kNone <= OsrTieringStateBit::kMax);
-  STATIC_ASSERT(TieringState::kInProgress <= OsrTieringStateBit::kMax);
+  STATIC_ASSERT(OsrTieringStateBit::is_valid(TieringState::kNone));
+  STATIC_ASSERT(OsrTieringStateBit::is_valid(TieringState::kInProgress));
   int32_t state = flags();
   state = OsrTieringStateBit::update(state, marker);
   set_flags(state);

--- a/deps/v8/src/objects/feedback-vector.h
+++ b/deps/v8/src/objects/feedback-vector.h
@@ -194,7 +194,7 @@ class FeedbackVector
  public:
   NEVER_READ_ONLY_SPACE
   DEFINE_TORQUE_GENERATED_FEEDBACK_VECTOR_FLAGS()
-  STATIC_ASSERT(TieringState::kLastTieringState <= TieringStateBits::kMax);
+  static_assert(TieringStateBits::is_valid(TieringState::kLastTieringState));
 
   static const bool kFeedbackVectorMaybeOptimizedCodeIsStoreRelease = true;
   using TorqueGeneratedFeedbackVector<FeedbackVector,

--- a/deps/v8/src/objects/js-date-time-format.h
+++ b/deps/v8/src/objects/js-date-time-format.h
@@ -118,23 +118,23 @@ class JSDateTimeFormat
   // Bit positions in |flags|.
   DEFINE_TORQUE_GENERATED_JS_DATE_TIME_FORMAT_FLAGS()
 
-  STATIC_ASSERT(HourCycle::kUndefined <= HourCycleBits::kMax);
-  STATIC_ASSERT(HourCycle::kH11 <= HourCycleBits::kMax);
-  STATIC_ASSERT(HourCycle::kH12 <= HourCycleBits::kMax);
-  STATIC_ASSERT(HourCycle::kH23 <= HourCycleBits::kMax);
-  STATIC_ASSERT(HourCycle::kH24 <= HourCycleBits::kMax);
+  static_assert(HourCycleBits::is_valid(HourCycle::kUndefined));
+  static_assert(HourCycleBits::is_valid(HourCycle::kH11));
+  static_assert(HourCycleBits::is_valid(HourCycle::kH12));
+  static_assert(HourCycleBits::is_valid(HourCycle::kH23));
+  static_assert(HourCycleBits::is_valid(HourCycle::kH24));
 
-  STATIC_ASSERT(DateTimeStyle::kUndefined <= DateStyleBits::kMax);
-  STATIC_ASSERT(DateTimeStyle::kFull <= DateStyleBits::kMax);
-  STATIC_ASSERT(DateTimeStyle::kLong <= DateStyleBits::kMax);
-  STATIC_ASSERT(DateTimeStyle::kMedium <= DateStyleBits::kMax);
-  STATIC_ASSERT(DateTimeStyle::kShort <= DateStyleBits::kMax);
+  static_assert(DateStyleBits::is_valid(DateTimeStyle::kUndefined));
+  static_assert(DateStyleBits::is_valid(DateTimeStyle::kFull));
+  static_assert(DateStyleBits::is_valid(DateTimeStyle::kLong));
+  static_assert(DateStyleBits::is_valid(DateTimeStyle::kMedium));
+  static_assert(DateStyleBits::is_valid(DateTimeStyle::kShort));
 
-  STATIC_ASSERT(DateTimeStyle::kUndefined <= TimeStyleBits::kMax);
-  STATIC_ASSERT(DateTimeStyle::kFull <= TimeStyleBits::kMax);
-  STATIC_ASSERT(DateTimeStyle::kLong <= TimeStyleBits::kMax);
-  STATIC_ASSERT(DateTimeStyle::kMedium <= TimeStyleBits::kMax);
-  STATIC_ASSERT(DateTimeStyle::kShort <= TimeStyleBits::kMax);
+  static_assert(TimeStyleBits::is_valid(DateTimeStyle::kUndefined));
+  static_assert(TimeStyleBits::is_valid(DateTimeStyle::kFull));
+  static_assert(TimeStyleBits::is_valid(DateTimeStyle::kLong));
+  static_assert(TimeStyleBits::is_valid(DateTimeStyle::kMedium));
+  static_assert(TimeStyleBits::is_valid(DateTimeStyle::kShort));
 
   DECL_ACCESSORS(icu_locale, Managed<icu::Locale>)
   DECL_ACCESSORS(icu_simple_date_format, Managed<icu::SimpleDateFormat>)

--- a/deps/v8/src/objects/js-display-names-inl.h
+++ b/deps/v8/src/objects/js-display-names-inl.h
@@ -25,7 +25,7 @@ ACCESSORS(JSDisplayNames, internal, Managed<DisplayNamesInternal>,
 TQ_OBJECT_CONSTRUCTORS_IMPL(JSDisplayNames)
 
 inline void JSDisplayNames::set_style(Style style) {
-  DCHECK_GE(StyleBits::kMax, style);
+  DCHECK(StyleBits::is_valid(style));
   set_flags(StyleBits::update(flags(), style));
 }
 
@@ -34,7 +34,7 @@ inline JSDisplayNames::Style JSDisplayNames::style() const {
 }
 
 inline void JSDisplayNames::set_fallback(Fallback fallback) {
-  DCHECK_GE(FallbackBit::kMax, fallback);
+  DCHECK(FallbackBit::is_valid(fallback));
   set_flags(FallbackBit::update(flags(), fallback));
 }
 
@@ -44,7 +44,7 @@ inline JSDisplayNames::Fallback JSDisplayNames::fallback() const {
 
 inline void JSDisplayNames::set_language_display(
     LanguageDisplay language_display) {
-  DCHECK_GE(LanguageDisplayBit::kMax, language_display);
+  DCHECK(LanguageDisplayBit::is_valid(language_display));
   set_flags(LanguageDisplayBit::update(flags(), language_display));
 }
 

--- a/deps/v8/src/objects/js-display-names.h
+++ b/deps/v8/src/objects/js-display-names.h
@@ -79,13 +79,13 @@ class JSDisplayNames
   // Bit positions in |flags|.
   DEFINE_TORQUE_GENERATED_JS_DISPLAY_NAMES_FLAGS()
 
-  STATIC_ASSERT(Style::kLong <= StyleBits::kMax);
-  STATIC_ASSERT(Style::kShort <= StyleBits::kMax);
-  STATIC_ASSERT(Style::kNarrow <= StyleBits::kMax);
-  STATIC_ASSERT(Fallback::kCode <= FallbackBit::kMax);
-  STATIC_ASSERT(Fallback::kNone <= FallbackBit::kMax);
-  STATIC_ASSERT(LanguageDisplay::kDialect <= LanguageDisplayBit::kMax);
-  STATIC_ASSERT(LanguageDisplay::kStandard <= LanguageDisplayBit::kMax);
+  static_assert(StyleBits::is_valid(Style::kLong));
+  static_assert(StyleBits::is_valid(Style::kShort));
+  static_assert(StyleBits::is_valid(Style::kNarrow));
+  static_assert(FallbackBit::is_valid(Fallback::kCode));
+  static_assert(FallbackBit::is_valid(Fallback::kNone));
+  static_assert(LanguageDisplayBit::is_valid(LanguageDisplay::kDialect));
+  static_assert(LanguageDisplayBit::is_valid(LanguageDisplay::kStandard));
 
   DECL_ACCESSORS(internal, Managed<DisplayNamesInternal>)
 

--- a/deps/v8/src/objects/js-list-format-inl.h
+++ b/deps/v8/src/objects/js-list-format-inl.h
@@ -27,7 +27,7 @@ ACCESSORS(JSListFormat, icu_formatter, Managed<icu::ListFormatter>,
           kIcuFormatterOffset)
 
 inline void JSListFormat::set_style(Style style) {
-  DCHECK_GE(StyleBits::kMax, style);
+  DCHECK(StyleBits::is_valid(style));
   int hints = flags();
   hints = StyleBits::update(hints, style);
   set_flags(hints);
@@ -38,7 +38,7 @@ inline JSListFormat::Style JSListFormat::style() const {
 }
 
 inline void JSListFormat::set_type(Type type) {
-  DCHECK_GE(TypeBits::kMax, type);
+  DCHECK(TypeBits::is_valid(type));
   int hints = flags();
   hints = TypeBits::update(hints, type);
   set_flags(hints);

--- a/deps/v8/src/objects/js-list-format.h
+++ b/deps/v8/src/objects/js-list-format.h
@@ -86,12 +86,12 @@ class JSListFormat
   // Bit positions in |flags|.
   DEFINE_TORQUE_GENERATED_JS_LIST_FORMAT_FLAGS()
 
-  STATIC_ASSERT(Style::LONG <= StyleBits::kMax);
-  STATIC_ASSERT(Style::SHORT <= StyleBits::kMax);
-  STATIC_ASSERT(Style::NARROW <= StyleBits::kMax);
-  STATIC_ASSERT(Type::CONJUNCTION <= TypeBits::kMax);
-  STATIC_ASSERT(Type::DISJUNCTION <= TypeBits::kMax);
-  STATIC_ASSERT(Type::UNIT <= TypeBits::kMax);
+  STATIC_ASSERT(StyleBits::is_valid(Style::LONG));
+  STATIC_ASSERT(StyleBits::is_valid(Style::SHORT));
+  STATIC_ASSERT(StyleBits::is_valid(Style::NARROW));
+  STATIC_ASSERT(TypeBits::is_valid(Type::CONJUNCTION));
+  STATIC_ASSERT(TypeBits::is_valid(Type::DISJUNCTION));
+  STATIC_ASSERT(TypeBits::is_valid(Type::UNIT));
 
   DECL_PRINTER(JSListFormat)
 

--- a/deps/v8/src/objects/js-plural-rules-inl.h
+++ b/deps/v8/src/objects/js-plural-rules-inl.h
@@ -33,7 +33,7 @@ ACCESSORS(JSPluralRules, icu_number_range_formatter,
           kIcuNumberRangeFormatterOffset)
 
 inline void JSPluralRules::set_type(Type type) {
-  DCHECK_LE(type, TypeBit::kMax);
+  DCHECK(TypeBit::is_valid(type));
   int hints = flags();
   hints = TypeBit::update(hints, type);
   set_flags(hints);

--- a/deps/v8/src/objects/js-plural-rules.h
+++ b/deps/v8/src/objects/js-plural-rules.h
@@ -66,8 +66,8 @@ class JSPluralRules
   // Bit positions in |flags|.
   DEFINE_TORQUE_GENERATED_JS_PLURAL_RULES_FLAGS()
 
-  STATIC_ASSERT(Type::CARDINAL <= TypeBit::kMax);
-  STATIC_ASSERT(Type::ORDINAL <= TypeBit::kMax);
+  STATIC_ASSERT(TypeBit::is_valid(Type::CARDINAL));
+  STATIC_ASSERT(TypeBit::is_valid(Type::ORDINAL));
 
   DECL_ACCESSORS(icu_plural_rules, Managed<icu::PluralRules>)
   DECL_ACCESSORS(icu_number_formatter,

--- a/deps/v8/src/objects/js-relative-time-format-inl.h
+++ b/deps/v8/src/objects/js-relative-time-format-inl.h
@@ -27,7 +27,7 @@ ACCESSORS(JSRelativeTimeFormat, icu_formatter,
           Managed<icu::RelativeDateTimeFormatter>, kIcuFormatterOffset)
 
 inline void JSRelativeTimeFormat::set_numeric(Numeric numeric) {
-  DCHECK_GE(NumericBit::kMax, numeric);
+  DCHECK(NumericBit::is_valid(numeric));
   int hints = flags();
   hints = NumericBit::update(hints, numeric);
   set_flags(hints);

--- a/deps/v8/src/objects/js-relative-time-format.h
+++ b/deps/v8/src/objects/js-relative-time-format.h
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "src/common/globals.h"
 #ifndef V8_INTL_SUPPORT
 #error Internationalization is expected to be enabled.
 #endif  // V8_INTL_SUPPORT
@@ -77,8 +78,8 @@ class JSRelativeTimeFormat
   // Bit positions in |flags|.
   DEFINE_TORQUE_GENERATED_JS_RELATIVE_TIME_FORMAT_FLAGS()
 
-  STATIC_ASSERT(Numeric::AUTO <= NumericBit::kMax);
-  STATIC_ASSERT(Numeric::ALWAYS <= NumericBit::kMax);
+  STATIC_ASSERT(NumericBit::is_valid(Numeric::AUTO));
+  STATIC_ASSERT(NumericBit::is_valid(Numeric::ALWAYS));
 
   DECL_PRINTER(JSRelativeTimeFormat)
 

--- a/deps/v8/src/objects/js-segment-iterator-inl.h
+++ b/deps/v8/src/objects/js-segment-iterator-inl.h
@@ -29,7 +29,7 @@ ACCESSORS(JSSegmentIterator, unicode_string, Managed<icu::UnicodeString>,
 
 inline void JSSegmentIterator::set_granularity(
     JSSegmenter::Granularity granularity) {
-  DCHECK_GE(GranularityBits::kMax, granularity);
+  DCHECK(GranularityBits::is_valid(granularity));
   int hints = flags();
   hints = GranularityBits::update(hints, granularity);
   set_flags(hints);

--- a/deps/v8/src/objects/js-segment-iterator.h
+++ b/deps/v8/src/objects/js-segment-iterator.h
@@ -55,9 +55,9 @@ class JSSegmentIterator
   // Bit positions in |flags|.
   DEFINE_TORQUE_GENERATED_JS_SEGMENT_ITERATOR_FLAGS()
 
-  STATIC_ASSERT(JSSegmenter::Granularity::GRAPHEME <= GranularityBits::kMax);
-  STATIC_ASSERT(JSSegmenter::Granularity::WORD <= GranularityBits::kMax);
-  STATIC_ASSERT(JSSegmenter::Granularity::SENTENCE <= GranularityBits::kMax);
+  STATIC_ASSERT(GranularityBits::is_valid(JSSegmenter::Granularity::GRAPHEME));
+  STATIC_ASSERT(GranularityBits::is_valid(JSSegmenter::Granularity::WORD));
+  STATIC_ASSERT(GranularityBits::is_valid(JSSegmenter::Granularity::SENTENCE));
 
   TQ_OBJECT_CONSTRUCTORS(JSSegmentIterator)
 };

--- a/deps/v8/src/objects/js-segmenter-inl.h
+++ b/deps/v8/src/objects/js-segmenter-inl.h
@@ -26,7 +26,7 @@ ACCESSORS(JSSegmenter, icu_break_iterator, Managed<icu::BreakIterator>,
           kIcuBreakIteratorOffset)
 
 inline void JSSegmenter::set_granularity(Granularity granularity) {
-  DCHECK_GE(GranularityBits::kMax, granularity);
+  DCHECK(GranularityBits::is_valid(granularity));
   int hints = flags();
   hints = GranularityBits::update(hints, granularity);
   set_flags(hints);

--- a/deps/v8/src/objects/js-segmenter.h
+++ b/deps/v8/src/objects/js-segmenter.h
@@ -65,9 +65,9 @@ class JSSegmenter : public TorqueGeneratedJSSegmenter<JSSegmenter, JSObject> {
   // Bit positions in |flags|.
   DEFINE_TORQUE_GENERATED_JS_SEGMENTER_FLAGS()
 
-  STATIC_ASSERT(Granularity::GRAPHEME <= GranularityBits::kMax);
-  STATIC_ASSERT(Granularity::WORD <= GranularityBits::kMax);
-  STATIC_ASSERT(Granularity::SENTENCE <= GranularityBits::kMax);
+  STATIC_ASSERT(GranularityBits::is_valid(Granularity::GRAPHEME));
+  STATIC_ASSERT(GranularityBits::is_valid(Granularity::WORD));
+  STATIC_ASSERT(GranularityBits::is_valid(Granularity::SENTENCE));
 
   DECL_PRINTER(JSSegmenter)
 

--- a/deps/v8/src/objects/js-segments-inl.h
+++ b/deps/v8/src/objects/js-segments-inl.h
@@ -28,7 +28,7 @@ ACCESSORS(JSSegments, unicode_string, Managed<icu::UnicodeString>,
           kUnicodeStringOffset)
 
 inline void JSSegments::set_granularity(JSSegmenter::Granularity granularity) {
-  DCHECK_GE(GranularityBits::kMax, granularity);
+  DCHECK(GranularityBits::is_valid(granularity));
   int hints = flags();
   hints = GranularityBits::update(hints, granularity);
   set_flags(hints);

--- a/deps/v8/src/objects/js-segments.h
+++ b/deps/v8/src/objects/js-segments.h
@@ -59,9 +59,9 @@ class JSSegments : public TorqueGeneratedJSSegments<JSSegments, JSObject> {
   // Bit positions in |flags|.
   DEFINE_TORQUE_GENERATED_JS_SEGMENT_ITERATOR_FLAGS()
 
-  STATIC_ASSERT(JSSegmenter::Granularity::GRAPHEME <= GranularityBits::kMax);
-  STATIC_ASSERT(JSSegmenter::Granularity::WORD <= GranularityBits::kMax);
-  STATIC_ASSERT(JSSegmenter::Granularity::SENTENCE <= GranularityBits::kMax);
+  STATIC_ASSERT(GranularityBits::is_valid(JSSegmenter::Granularity::GRAPHEME));
+  STATIC_ASSERT(GranularityBits::is_valid(JSSegmenter::Granularity::WORD));
+  STATIC_ASSERT(GranularityBits::is_valid(JSSegmenter::Granularity::SENTENCE));
 
   TQ_OBJECT_CONSTRUCTORS(JSSegments)
 };

--- a/deps/v8/src/objects/scope-info.h
+++ b/deps/v8/src/objects/scope-info.h
@@ -294,7 +294,7 @@ class ScopeInfo : public TorqueGeneratedScopeInfo<ScopeInfo, HeapObject> {
   };
 
   STATIC_ASSERT(LanguageModeSize == 1 << LanguageModeBit::kSize);
-  STATIC_ASSERT(FunctionKind::kLastFunctionKind <= FunctionKindBits::kMax);
+  STATIC_ASSERT(FunctionKindBits::is_valid(FunctionKind::kLastFunctionKind));
 
   bool IsEmpty() const;
 

--- a/deps/v8/src/objects/shared-function-info.h
+++ b/deps/v8/src/objects/shared-function-info.h
@@ -671,12 +671,12 @@ class SharedFunctionInfo
   class BodyDescriptor;
 
   // Bailout reasons must fit in the DisabledOptimizationReason bitfield.
-  STATIC_ASSERT(BailoutReason::kLastErrorMessage <=
-                DisabledOptimizationReasonBits::kMax);
+  STATIC_ASSERT(DisabledOptimizationReasonBits::is_valid(
+      BailoutReason::kLastErrorMessage));
 
-  STATIC_ASSERT(FunctionKind::kLastFunctionKind <= FunctionKindBits::kMax);
-  STATIC_ASSERT(FunctionSyntaxKind::kLastFunctionSyntaxKind <=
-                FunctionSyntaxKindBits::kMax);
+  STATIC_ASSERT(FunctionKindBits::is_valid(FunctionKind::kLastFunctionKind));
+  STATIC_ASSERT(FunctionSyntaxKindBits::is_valid(
+      FunctionSyntaxKind::kLastFunctionSyntaxKind));
 
   // Sets the bytecode in {shared}'s DebugInfo as the bytecode to
   // be returned by following calls to GetActiveBytecodeArray. Stores a

--- a/eng/patches/MSFT-use_libc++_for_host_and_target.patch
+++ b/eng/patches/MSFT-use_libc++_for_host_and_target.patch
@@ -7,7 +7,7 @@ index 4a0e093fa4..094f0e8151 100644
        [ 'OS in "linux freebsd openbsd solaris android aix os400 cloudabi"', {
          'cflags': [ '-Wall', '-Wextra', '-Wno-unused-parameter', ],
 -        'cflags_cc': [ '-fno-rtti', '-fno-exceptions', '-std=gnu++17' ],
-+        'cflags_cc': [ '-fno-rtti', '-fno-exceptions', '-std=gnu++17', '-stdlib=libc++', '-Wno-error=enum-constexpr-conversion' ],
++        'cflags_cc': [ '-fno-rtti', '-fno-exceptions', '-std=gnu++17', '-stdlib=libc++' ],
          'defines': [ '__STDC_FORMAT_MACROS' ],
          'ldflags': [ '-rdynamic', '-fuse-ld=lld', '-Wl,--build-id' ],
          'target_conditions': [

--- a/node.proj
+++ b/node.proj
@@ -177,9 +177,7 @@
       <LDFlagsHost Condition="'$(BuildOS)' == 'Linux' and '$(TargetArchitecture)' == 'arm64'">-target aarch64-linux-gnu</LDFlagsHost>
       <LDFlagsHost Condition="'$(BuildOS)' == 'Linux'">$(LDFlagsHost) --gcc-toolchain=$(RootFsDirHost)/usr/ --sysroot=$(RootFsDirHost)/</LDFlagsHost>
       <LDFlagsHost>$(LDFlagsHost) -Wl,-rpath,$([MSBuild]::NormalizePath('$(MonoLLVMDir)\$(BuildArchitecture)\lib'))</LDFlagsHost>
-      <CXXFlags>$(CFlags) -Wno-error=enum-constexpr-conversion</CXXFlags>
       <CXXFlags Condition="'$(BuildOS)' == 'Linux'">$(CXXFlags) -I$([MSBuild]::NormalizePath('$(MonoLLVMDir)\$(MonoLLVMTargetOSPrefix)$(TargetArchitecture)\include\c++\v1')) -L$([MSBuild]::NormalizePath('$(MonoLLVMDir)\$(MonoLLVMTargetOSPrefix)$(TargetArchitecture)\lib')) -lc++ -stdlib=libc++</CXXFlags>
-      <CXXFlagsHost>$(CFlagsHost) -Wno-error=enum-constexpr-conversion</CXXFlagsHost>
       <CXXFlagsHost Condition="'$(BuildOS)' == 'Linux'">$(CXXFlags) -I$([MSBuild]::NormalizePath('$(MonoLLVMDir)\$(BuildArchitecture)\include\c++\v1')) -L$([MSBuild]::NormalizePath('$(MonoLLVMDir)\$(BuildArchitecture)\lib')) -lc++ -stdlib=libc++ -Wl,-rpath,$([MSBuild]::NormalizePath('$(MonoLLVMDir)\$(BuildArchitecture)\lib'))</CXXFlagsHost>
       <ConfigureEnvironment Condition="'$(BuildOS)' == 'Linux'">$(ConfigureEnvironment) GYP_DEFINES="$(GypEnvironment)"</ConfigureEnvironment>
       <ConfigureCommand>PATH=$(PythonPrefixedPath) $(ConfigureEnvironment) ./configure $(ConfigureFlags)</ConfigureCommand>

--- a/node.proj
+++ b/node.proj
@@ -177,7 +177,9 @@
       <LDFlagsHost Condition="'$(BuildOS)' == 'Linux' and '$(TargetArchitecture)' == 'arm64'">-target aarch64-linux-gnu</LDFlagsHost>
       <LDFlagsHost Condition="'$(BuildOS)' == 'Linux'">$(LDFlagsHost) --gcc-toolchain=$(RootFsDirHost)/usr/ --sysroot=$(RootFsDirHost)/</LDFlagsHost>
       <LDFlagsHost>$(LDFlagsHost) -Wl,-rpath,$([MSBuild]::NormalizePath('$(MonoLLVMDir)\$(BuildArchitecture)\lib'))</LDFlagsHost>
+      <CXXFlags>$(CFlags)</CXXFlags>
       <CXXFlags Condition="'$(BuildOS)' == 'Linux'">$(CXXFlags) -I$([MSBuild]::NormalizePath('$(MonoLLVMDir)\$(MonoLLVMTargetOSPrefix)$(TargetArchitecture)\include\c++\v1')) -L$([MSBuild]::NormalizePath('$(MonoLLVMDir)\$(MonoLLVMTargetOSPrefix)$(TargetArchitecture)\lib')) -lc++ -stdlib=libc++</CXXFlags>
+      <CXXFlagsHost>$(CFlagsHost)</CXXFlagsHost>
       <CXXFlagsHost Condition="'$(BuildOS)' == 'Linux'">$(CXXFlags) -I$([MSBuild]::NormalizePath('$(MonoLLVMDir)\$(BuildArchitecture)\include\c++\v1')) -L$([MSBuild]::NormalizePath('$(MonoLLVMDir)\$(BuildArchitecture)\lib')) -lc++ -stdlib=libc++ -Wl,-rpath,$([MSBuild]::NormalizePath('$(MonoLLVMDir)\$(BuildArchitecture)\lib'))</CXXFlagsHost>
       <ConfigureEnvironment Condition="'$(BuildOS)' == 'Linux'">$(ConfigureEnvironment) GYP_DEFINES="$(GypEnvironment)"</ConfigureEnvironment>
       <ConfigureCommand>PATH=$(PythonPrefixedPath) $(ConfigureEnvironment) ./configure $(ConfigureFlags)</ConfigureCommand>


### PR DESCRIPTION
Port of https://github.com/v8/v8/commit/64a4e25b9e579161f169d3a6afd59aba492ce91a. Fixes the build on later clang versions that make this a hard error.